### PR TITLE
Save `birthday` and `lastContacted` to storage

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ContactedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ContactedCommand.java
@@ -1,0 +1,18 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+
+import seedu.address.commons.core.index.Index;
+
+public class ContactedCommand extends EditCommand {
+    public static final String COMMAND_WORD = "contacted";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the last contacted datetime of the client "
+            + "identified by the index number used in the displayed client list.\n"
+            + "Parameters: INDEX (must be a positive integer) " + PREFIX_DATETIME + "DATETIME\n"
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATETIME + "21-03-2022 21:03";
+
+    public ContactedCommand(Index index, EditClientDescriptor editClientDescriptor) {
+        super(index, editClientDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,8 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LAST_CONTACTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
@@ -52,12 +52,12 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY] "
-            + "[" + PREFIX_LAST_CONTACTED + "LAST CONTACTED]\n"
+            + "[" + PREFIX_DATETIME + "LAST CONTACTED]\n"
             // + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com"
-            + PREFIX_LAST_CONTACTED + "21/03/2022 21:03";
+            + PREFIX_DATETIME + "21/03/2022 21:03";
 
     public static final String MESSAGE_EDIT_CLIENT_SUCCESS = "Edited Client: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LAST_CONTACTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
@@ -52,7 +53,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY] "
-            + "[" + PREFIX_DATETIME + "LAST CONTACTED]\n"
+            + "[" + PREFIX_LAST_CONTACTED + "LAST CONTACTED]\n"
             // + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -89,7 +90,6 @@ public class EditCommand extends Command {
     public EditCommand(Index index, EditClientDescriptor editClientDescriptor, boolean isDelete) {
         requireNonNull(index);
         requireNonNull(editClientDescriptor);
-        requireNonNull(isDelete);
 
         this.index = index;
         this.editClientDescriptor = new EditClientDescriptor(editClientDescriptor);
@@ -181,7 +181,7 @@ public class EditCommand extends Command {
 
             if (isDelete) {
                 updatedPolicies.remove(index);
-            } else if (isUpdate) {
+            } else {
                 Policy policyToUpdate = updatedPolicies.get(index);
                 updatedPolicyName = editClientDescriptor.getPolicyName().orElse(policyToUpdate.getName());
                 updatedCompany = editClientDescriptor.getCompany().orElse(policyToUpdate.getCompany());

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -6,6 +6,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.ParserUtil.DEFAULT_DATE;
+import static seedu.address.logic.parser.ParserUtil.DEFAULT_DATETIME;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -14,6 +16,8 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
+import seedu.address.model.client.DateTime;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -42,9 +46,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Date birthday = new Date(DEFAULT_DATE);
+        DateTime lastContacted = new DateTime(DEFAULT_DATETIME);
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Client client = new Client(name, phone, email, address, tagList);
+        Client client = new Client(name, phone, email, address, birthday, lastContacted, tagList);
 
         return new AddCommand(client);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.commands.AddPreferenceCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.ContactedCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeletePreferenceCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -72,6 +73,9 @@ public class AddressBookParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
+        case ContactedCommand.COMMAND_WORD:
+            return new ContactedCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,6 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_BIRTHDAY = new Prefix("b/");
+    public static final Prefix PREFIX_LAST_CONTACTED = new Prefix("lc/");
     public static final Prefix PREFIX_DATETIME = new Prefix("dt/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_START_DATETIME = new Prefix("ms/");

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,7 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_BIRTHDAY = new Prefix("b/");
-    public static final Prefix PREFIX_LAST_CONTACTED = new Prefix("lc/");
+    public static final Prefix PREFIX_DATETIME = new Prefix("dt/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_START_DATETIME = new Prefix("ms/");
     public static final Prefix PREFIX_END_DATETIME = new Prefix("me/");

--- a/src/main/java/seedu/address/logic/parser/ContactedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ContactedCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddNoteCommand;
+import seedu.address.logic.commands.ContactedCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.client.DateTime;
+
+/**
+ * Parses input arguments and creates a new ContactedCommand object
+ */
+public class ContactedCommandParser implements Parser<ContactedCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ContactedCommand
+     * and returns a ContactedCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    public ContactedCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DATETIME);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_DATETIME)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ContactedCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException((String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE)));
+        }
+
+        EditCommand.EditClientDescriptor editClientDescriptor = new EditCommand.EditClientDescriptor();
+
+        DateTime contacted = ParserUtil.parseLastContacted(argMultimap.getValue(PREFIX_DATETIME).get());
+
+        editClientDescriptor.setLastContacted(contacted);
+        return new ContactedCommand(index, editClientDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LAST_CONTACTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -35,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_DATETIME, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_LAST_CONTACTED, PREFIX_TAG);
 
         Index index;
 
@@ -61,9 +61,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_BIRTHDAY).isPresent()) {
             editClientDescriptor.setBirthday(ParserUtil.parseDate(argMultimap.getValue(PREFIX_BIRTHDAY).get()));
         }
-        if (argMultimap.getValue(PREFIX_DATETIME).isPresent()) {
+        if (argMultimap.getValue(PREFIX_LAST_CONTACTED).isPresent()) {
             editClientDescriptor.setLastContacted(ParserUtil.parseLastContacted(argMultimap
-                    .getValue(PREFIX_DATETIME).get()));
+                    .getValue(PREFIX_LAST_CONTACTED).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editClientDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LAST_CONTACTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -35,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_LAST_CONTACTED, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_DATETIME, PREFIX_TAG);
 
         Index index;
 
@@ -61,9 +61,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_BIRTHDAY).isPresent()) {
             editClientDescriptor.setBirthday(ParserUtil.parseDate(argMultimap.getValue(PREFIX_BIRTHDAY).get()));
         }
-        if (argMultimap.getValue(PREFIX_LAST_CONTACTED).isPresent()) {
+        if (argMultimap.getValue(PREFIX_DATETIME).isPresent()) {
             editClientDescriptor.setLastContacted(ParserUtil.parseLastContacted(argMultimap
-                    .getValue(PREFIX_LAST_CONTACTED).get()));
+                    .getValue(PREFIX_DATETIME).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editClientDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -29,6 +29,8 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String DEFAULT_DATE = "01-01-0001";
+    public static final String DEFAULT_DATETIME = "01-01-0001 00:00";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -35,12 +35,15 @@ public class Client {
     /**
      * Every field must be present and not null.
      */
-    public Client(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
+    public Client(Name name, Phone phone, Email email, Address address, Date birthday, DateTime lastContacted,
+                  Set<Tag> tags) {
+        requireAllNonNull(name, phone, email, address, birthday, lastContacted, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.birthday = birthday;
+        this.lastContacted = lastContacted;
         this.tags.addAll(tags);
     }
 

--- a/src/main/java/seedu/address/model/client/Date.java
+++ b/src/main/java/seedu/address/model/client/Date.java
@@ -12,12 +12,12 @@ import java.time.format.DateTimeFormatter;
  */
 public class Date {
 
-    public static final String MESSAGE_CONSTRAINTS = "Date should be in dd/MM/yyyy format.";
+    public static final String MESSAGE_CONSTRAINTS = "Date should be in dd-MM-yyyy format.";
 
     /*
-     * Date should be in dd/MM/yyyy format.
+     * Date should be in dd-MM-yyyy format.
      */
-    public static final String VALIDATION_REGEX = "^([0-2][0-9]|(3)[0-1])(/)(((0)[0-9])|((1)[0-2]))(/)\\d{4}$";
+    public static final String VALIDATION_REGEX = "^([012][1-9]|3[01])-([0][1-9]|1[012])-([0-9][0-9][0-9][1-9])$";
 
     public final LocalDate value;
 
@@ -41,7 +41,11 @@ public class Date {
 
     @Override
     public String toString() {
-        return value.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        String result = value.format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+        if (result.equals("01-01-0001")) {
+            return "-";
+        }
+        return result;
     }
 
     @Override
@@ -57,6 +61,6 @@ public class Date {
     }
 
     public LocalDate parse(String date) {
-        return LocalDate.parse(date, DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        return LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MM-yyyy"));
     }
 }

--- a/src/main/java/seedu/address/model/client/DateTime.java
+++ b/src/main/java/seedu/address/model/client/DateTime.java
@@ -15,10 +15,10 @@ public class DateTime {
     public static final String MESSAGE_CONSTRAINTS = "Datetime should be in DD-MM-YYYY HH:mm format.";
 
     /*
-     * Datetime should be in DD/MM/YYYY HH:mm format.
+     * Datetime should be in dd-MM-yyyy HH:mm format.
      */
-    public static final String VALIDATION_REGEX = "^([1-9]|([012][0-9])|(3[01]))-([0]{0,1}[1-9]|1[012])"
-            + "-\\d\\d\\d\\d\\s([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
+    public static final String VALIDATION_REGEX =
+            "^([012][1-9]|3[01])-([0][1-9]|1[012])-([0-9][0-9][0-9][1-9])\\s([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
 
     public final LocalDateTime value;
 
@@ -42,7 +42,11 @@ public class DateTime {
 
     @Override
     public String toString() {
-        return value.format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
+        String result = value.format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
+        if (result.equals("01-01-0001 00:00")) {
+            return "-";
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/client/DateTime.java
+++ b/src/main/java/seedu/address/model/client/DateTime.java
@@ -12,13 +12,13 @@ import java.time.format.DateTimeFormatter;
  */
 public class DateTime {
 
-    public static final String MESSAGE_CONSTRAINTS = "Datetime should be in DD/MM/YYYY HH:mm format.";
+    public static final String MESSAGE_CONSTRAINTS = "Datetime should be in DD-MM-YYYY HH:mm format.";
 
     /*
      * Datetime should be in DD/MM/YYYY HH:mm format.
      */
-    public static final String VALIDATION_REGEX = "^([1-9]|([012][0-9])|(3[01]))/([0]{0,1}[1-9]|1[012])"
-            + "/\\d\\d\\d\\d\\s([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
+    public static final String VALIDATION_REGEX = "^([1-9]|([012][0-9])|(3[01]))-([0]{0,1}[1-9]|1[012])"
+            + "-\\d\\d\\d\\d\\s([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
 
     public final LocalDateTime value;
 
@@ -42,7 +42,7 @@ public class DateTime {
 
     @Override
     public String toString() {
-        return value.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm"));
+        return value.format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
     }
 
     @Override
@@ -58,6 +58,6 @@ public class DateTime {
     }
 
     public LocalDateTime parse(String dateTime) {
-        return LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm"));
+        return LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
     }
 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -10,6 +10,8 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
+import seedu.address.model.client.DateTime;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -24,23 +26,23 @@ public class SampleDataUtil {
     public static Client[] getSampleClients() {
         return new Client[] {
             new Client(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
+                new Address("Blk 30 Geylang Street 29, #06-40"), new Date("21-03-1999"),
+                    new DateTime("21-03-1999 21:03"), getTagSet("friends")),
             new Client(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Date("21-03-2001"),
+                    new DateTime("21-03-1999 21:03"), getTagSet("colleagues", "friends")),
             new Client(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Date("21-03-2001"),
+                    new DateTime("21-03-1999 21:03"), getTagSet("neighbours")),
             new Client(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Date("21-03-1999"),
+                    new DateTime("21-03-1999 21:03"), getTagSet("family")),
             new Client(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
+                new Address("Blk 47 Tampines Street 20, #17-35"), new Date("21-03-1999"),
+                    new DateTime("21-03-1999 21:03"), getTagSet("classmates")),
             new Client(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
+                new Address("Blk 45 Aljunied Street 85, #11-31"), new Date("21-03-1999"),
+                    new DateTime("21-03-1999 21:03"), getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
+import seedu.address.model.client.DateTime;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Note;
@@ -31,6 +33,8 @@ class JsonAdaptedClient {
     private final String phone;
     private final String email;
     private final String address;
+    private final String birthday;
+    private final String lastContacted;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
     private final List<JsonAdaptedPolicy> policies = new ArrayList<>();
     private final String note;
@@ -41,14 +45,19 @@ class JsonAdaptedClient {
      */
     @JsonCreator
     public JsonAdaptedClient(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-            @JsonProperty("policies") List<JsonAdaptedPolicy> policies, @JsonProperty("note") String note,
-            @JsonProperty("preferenceMap") JsonAdaptedPreferenceMap preferenceMap) {
+                             @JsonProperty("email") String email, @JsonProperty("address") String address,
+                             @JsonProperty("birthday") String birthday,
+                             @JsonProperty("lastContacted") String lastContacted,
+                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+                             @JsonProperty("policies") List<JsonAdaptedPolicy> policies,
+                             @JsonProperty("note") String note,
+                             @JsonProperty("preferenceMap") JsonAdaptedPreferenceMap preferenceMap) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.birthday = birthday;
+        this.lastContacted = lastContacted;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -75,6 +84,8 @@ class JsonAdaptedClient {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
+        birthday = source.getBirthday().toString();
+        lastContacted = source.getLastContacted().toString();
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -132,6 +143,26 @@ class JsonAdaptedClient {
         }
         final Address modelAddress = new Address(address);
 
+        final Date modelBirthday;
+        if (birthday == null) {
+            modelBirthday = new Date("01-01-0001");
+        } else {
+            if (!Date.isValidDate(birthday)) {
+                throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+            }
+            modelBirthday = new Date(birthday);
+        }
+
+        final DateTime modelLastContacted;
+        if (lastContacted == null) {
+            modelLastContacted = new DateTime("01-01-0001 00:00");
+        } else {
+            if (!DateTime.isValidDateTime(lastContacted)) {
+                throw new IllegalValueException(DateTime.MESSAGE_CONSTRAINTS);
+            }
+            modelLastContacted = new DateTime(lastContacted);
+        }
+
         if (note == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Note.class.getSimpleName()));
         }
@@ -148,8 +179,7 @@ class JsonAdaptedClient {
         final Set<Tag> modelTags = new HashSet<>(clientTags);
         final List<Policy> modelPolicies = new ArrayList<>(clientPolicies);
 
-        return new Client(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelPolicies, modelNote,
-                modelPreferenceMap);
+        return new Client(modelName, modelPhone, modelEmail, modelAddress, modelBirthday, modelLastContacted, modelTags,
+                modelPolicies, modelNote, modelPreferenceMap);
     }
-
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
@@ -29,6 +29,8 @@ public class JsonAdaptedClientTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_BIRTHDAY = BENSON.getBirthday().toString();
+    private static final String VALID_LAST_CONTACTED = BENSON.getLastContacted().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -46,9 +48,8 @@ public class JsonAdaptedClientTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+        JsonAdaptedClient client = new JsonAdaptedClient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -56,16 +57,15 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -73,16 +73,15 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -90,16 +89,15 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS,
-                        VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -107,7 +105,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -116,9 +114,8 @@ public class JsonAdaptedClientTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags,
-                        VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, invalidTags, VALID_POLICIES, VALID_NOTE, VALID_PREFERENCES);
         assertThrows(IllegalValueException.class, client::toModelType);
     }
 
@@ -126,9 +123,8 @@ public class JsonAdaptedClientTest {
     public void toModelType_invalidPolicies_throwsIllegalValueException() {
         List<JsonAdaptedPolicy> invalidPolicies = new ArrayList<>(VALID_POLICIES);
         invalidPolicies.add(new JsonAdaptedPolicy(INVALID_NAME, INVALID_NAME, INVALID_NAME, INVALID_PREMIUM));
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        invalidPolicies, VALID_NOTE, VALID_PREFERENCES);
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_BIRTHDAY, VALID_LAST_CONTACTED, VALID_TAGS, invalidPolicies, VALID_NOTE, VALID_PREFERENCES);
         assertThrows(IllegalValueException.class, client::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
+import seedu.address.model.client.DateTime;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Note;
@@ -23,6 +25,8 @@ public class ClientBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_BIRTHDAY = "21-03-1999";
+    public static final String DEFAULT_LAST_CONTACTED = "21-03-1999 21:03";
 
     public static final String DEFAULT_POLICY_NAME = "Big Insurance Policy";
     public static final String DEFAULT_COMPANY = "Big Insurance Company";
@@ -34,10 +38,11 @@ public class ClientBuilder {
     private Phone phone;
     private Email email;
     private Address address;
+    private Date birthday;
+    private DateTime lastContacted;
     private Set<Tag> tags;
     private Set<Policy> policies = new HashSet<>();
     private Note note;
-
 
     /**
      * Creates a {@code ClientBuilder} with the default details.
@@ -47,6 +52,8 @@ public class ClientBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        birthday = new Date(DEFAULT_BIRTHDAY);
+        lastContacted = new DateTime(DEFAULT_LAST_CONTACTED);
         tags = new HashSet<>();
 
         Policy defaultPolicy = new Policy(new Name(DEFAULT_POLICY_NAME), new Name(DEFAULT_COMPANY),
@@ -64,6 +71,8 @@ public class ClientBuilder {
         phone = clientToCopy.getPhone();
         email = clientToCopy.getEmail();
         address = clientToCopy.getAddress();
+        birthday = clientToCopy.getBirthday();
+        lastContacted = clientToCopy.getLastContacted();
         tags = new HashSet<>(clientToCopy.getTags());
         policies = new HashSet<>(clientToCopy.getPolicies());
         note = clientToCopy.getNote();
@@ -90,6 +99,22 @@ public class ClientBuilder {
      */
     public ClientBuilder withAddress(String address) {
         this.address = new Address(address);
+        return this;
+    }
+
+    /**
+     * Sets the {@code birthday} of the {@code Client} that we are building.
+     */
+    public ClientBuilder withBirthday(String birthday) {
+        this.birthday = new Date(birthday);
+        return this;
+    }
+
+    /**
+     * Sets the {@code lastContacted} of the {@code Client} that we are building.
+     */
+    public ClientBuilder withLastContacted(String lastContacted) {
+        this.lastContacted = new DateTime(lastContacted);
         return this;
     }
 
@@ -126,7 +151,7 @@ public class ClientBuilder {
     }
 
     public Client build() {
-        return new Client(name, phone, email, address, tags);
+        return new Client(name, phone, email, address, birthday, lastContacted, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/ClientUtil.java
+++ b/src/test/java/seedu/address/testutil/ClientUtil.java
@@ -1,7 +1,9 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LAST_CONTACTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -30,12 +32,12 @@ public class ClientUtil {
      */
     public static String getClientDetails(Client client) {
         StringBuilder sb = new StringBuilder();
-        sb.append(PREFIX_NAME + client.getName().fullName + " ");
-        sb.append(PREFIX_PHONE + client.getPhone().value + " ");
-        sb.append(PREFIX_EMAIL + client.getEmail().value + " ");
-        sb.append(PREFIX_ADDRESS + client.getAddress().value + " ");
-        client.getTags().stream().forEach(
-            s -> sb.append(PREFIX_TAG + s.tagName + " ")
+        sb.append(PREFIX_NAME).append(client.getName().fullName).append(" ");
+        sb.append(PREFIX_PHONE).append(client.getPhone().value).append(" ");
+        sb.append(PREFIX_EMAIL).append(client.getEmail().value).append(" ");
+        sb.append(PREFIX_ADDRESS).append(client.getAddress().value).append(" ");
+        client.getTags().forEach(
+            s -> sb.append(PREFIX_TAG).append(s.tagName).append(" ")
         );
         return sb.toString();
     }
@@ -49,6 +51,9 @@ public class ClientUtil {
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
+        descriptor.getBirthday().ifPresent(birthday -> sb.append(PREFIX_BIRTHDAY).append(birthday).append(" "));
+        descriptor.getLastContacted().ifPresent(lastContacted -> sb.append(PREFIX_LAST_CONTACTED).append(lastContacted)
+                .append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/TypicalClients.java
+++ b/src/test/java/seedu/address/testutil/TypicalClients.java
@@ -31,9 +31,8 @@ public class TypicalClients {
             .withPhone("94351253")
             .withTags("friends").build();
     public static final Client BENSON = new ClientBuilder().withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends")
+            .withAddress("311, Clementi Ave 2, #02-25").withBirthday("21-03-1999").withLastContacted("21-03-1999 21:03")
+            .withEmail("johnd@example.com").withPhone("98765432").withTags("owesMoney", "friends")
             .withPolicies(
                     new Policy(
                             new Name("life insurance"), new Name("insurance company"),


### PR DESCRIPTION
Closes #93 and #10

### Changes

- [x] Update `birthday` and `lastContacted` to be non-null fields with default values i.e. `01-01-0001 00:00`, which shows as no `birthday` or `lastContacted` data
- [x] Save `birthday` and `lastContacted` to storage
- [x] Users can now update their clients' `lastContacted` through the `ContactedCommand` (using the `DateTime` `Prefix` `dt/ dd-MM-yyyy hh:mm`) **or** the `EditCommand` (using the `lastContacted` `Prefix` `[lc/ dd-MM-yyy hh:mm]`) 
- [x] Update tests, specifically those on loading data, to account for `birthday` and `lastContacted`