### PR TITLE
Add `lastContacted` preamble support in `sortClients` command to sort clients by `lastContacted`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -61,6 +61,9 @@ public class SortCommand extends Command {
         case "premium":
             comparator = Comparator.comparingInt(a -> a.getPolicies().totalPremiumSum());
             break;
+        case "lastContacted":
+            comparator = Comparator.comparing(a -> a.getLastContacted().getDateTime());
+            break;
         default:
             throw new CommandException(MESSAGE_INVALID_ATTRIBUTE);
         }
@@ -68,6 +71,7 @@ public class SortCommand extends Command {
         if (!isAscending) {
             comparator = comparator.reversed();
         }
+
         model.updateSortedClientList(comparator);
         return new CommandResult(String.format(MESSAGE_SUCCESS), true);
     }

--- a/src/main/java/seedu/address/model/client/DateTime.java
+++ b/src/main/java/seedu/address/model/client/DateTime.java
@@ -44,6 +44,16 @@ public class DateTime {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns the datetime as a {@code LocalDateTime} object.
+     */
+    public LocalDateTime getDateTime() {
+        if (value.equals("")) {
+            return LocalDateTime.parse("01-01-0001 00:00", DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
+        }
+        return LocalDateTime.parse(value, DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
+    }
+
     @Override
     public String toString() {
         return value;
@@ -73,9 +83,5 @@ public class DateTime {
     @Override
     public int hashCode() {
         return value.hashCode();
-    }
-
-    public LocalDateTime parse(String dateTime) {
-        return LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
     }
 }


### PR DESCRIPTION
Closes #10

### Changes

- [x] Add `lastContacted` preamble support in `sortClients` command to sort clients by `lastContacted` 