### PR TITLE
Change meeting display dynamically

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -56,5 +56,8 @@ public interface Logic {
      */
     void setGuiSettings(GuiSettings guiSettings);
 
+    /**
+     * Returns whether all or only upcoming meetings are displayed.
+     */
     boolean isShowAllMeetings();
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -55,4 +55,6 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    boolean isShowAllMeetings();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -89,4 +89,9 @@ public class LogicManager implements Logic {
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
     }
+
+    @Override
+    public boolean isShowAllMeetings() {
+        return model.isShowAllMeetings();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/meeting/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/EditMeetingCommand.java
@@ -79,7 +79,7 @@ public class EditMeetingCommand extends Command {
         }
 
         model.setMeeting(meetingToEdit, editedMeeting);
-        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS, model.isShowAllMeetings());
         return new CommandResult(String.format(MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting));
     }
 

--- a/src/main/java/seedu/address/logic/commands/meeting/ListMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ListMeetingCommand.java
@@ -97,7 +97,7 @@ public class ListMeetingCommand extends Command {
             client = model.getFilteredClientList().get(index.getZeroBased());
         }
 
-        model.updateFilteredMeetingList(generatePredicate(isShowAll, client));
+        model.updateFilteredMeetingList(generatePredicate(isShowAll, client), isShowAll);
 
         return new CommandResult(generateSuccessMessage(isShowAll, client),
                 false,

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -151,11 +151,13 @@ public interface Model {
      */
     ObservableList<Meeting> getFilteredMeetingList();
 
+    boolean isShowAllMeetings();
+
     /**
      * Updates the filter of the filtered meeting list to filter by the given {@code predicate}.
      *
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredMeetingList(Predicate<Meeting> predicate);
+    void updateFilteredMeetingList(Predicate<Meeting> predicate, boolean isShowAll);
 }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -151,6 +151,9 @@ public interface Model {
      */
     ObservableList<Meeting> getFilteredMeetingList();
 
+    /**
+     * Returns whether all or only upcoming meetings are displayed.
+     */
     boolean isShowAllMeetings();
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -27,6 +27,7 @@ public class ModelManager implements Model {
     private final FilteredList<Client> filteredClients;
     private final FilteredList<Meeting> filteredMeetings;
     private final SortedList<Client> sortedClients;
+    private boolean isShowAllMeetings = false;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -133,7 +134,12 @@ public class ModelManager implements Model {
     @Override
     public void addMeeting(Meeting meeting) {
         addressBook.addMeeting(meeting);
-        updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+        updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS, isShowAllMeetings);
+    }
+
+    @Override
+    public boolean isShowAllMeetings() {
+        return isShowAllMeetings;
     }
 
     @Override
@@ -190,8 +196,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
+    public void updateFilteredMeetingList(Predicate<Meeting> predicate, boolean isShowAll) {
         requireNonNull(predicate);
+        this.isShowAllMeetings = isShowAll;
         filteredMeetings.setPredicate(predicate);
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -223,6 +223,9 @@ public class MainWindow extends UiPart<Stage> {
         meetingListPanelPlaceholder.getChildren().add(clientDisplay.getRoot());
     }
 
+    /**
+     * Display sorted clients.
+     */
     private void showSortedClients() {
         clientListPanelPlaceholder.getChildren().clear();
         clientListPanel = new ClientListPanel(logic.getSortedClientList());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -121,7 +121,7 @@ public class MainWindow extends UiPart<Stage> {
         clientListPanel = new ClientListPanel(logic.getFilteredClientList());
         clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
 
-        meetingListPanel = new MeetingListPanel(logic.getFilteredMeetingList());
+        meetingListPanel = new MeetingListPanel(logic.getFilteredMeetingList(), logic.isShowAllMeetings());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -195,10 +195,11 @@ public class MainWindow extends UiPart<Stage> {
      */
     private void showMeetings() {
         meetingListPanelPlaceholder.getChildren().clear();
+        meetingListPanel = new MeetingListPanel(logic.getFilteredMeetingList(), logic.isShowAllMeetings());
         meetingListPanelPlaceholder.getChildren().add(meetingListPanel.getRoot());
 
         if (logic.getFilteredMeetingList().size() == 0) {
-            resultDisplay.setFeedbackToUser("Add meetings by using the addMeeting command!");
+            resultDisplay.setFeedbackToUser("No meetings to display.\nAdd meetings by using the addMeeting command!");
         }
     }
 
@@ -220,6 +221,12 @@ public class MainWindow extends UiPart<Stage> {
         clientDisplay = new ClientDisplay(logic.getFilteredClientList().get(index.getZeroBased()));
         meetingListPanelPlaceholder.getChildren().clear();
         meetingListPanelPlaceholder.getChildren().add(clientDisplay.getRoot());
+    }
+
+    private void showSortedClients() {
+        clientListPanelPlaceholder.getChildren().clear();
+        clientListPanel = new ClientListPanel(logic.getSortedClientList());
+        clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
     }
 
     public ClientListPanel getClientListPanel() {
@@ -258,9 +265,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             if (commandResult.isSortClients()) {
-                clientListPanelPlaceholder.getChildren().clear();
-                clientListPanel = new ClientListPanel(logic.getSortedClientList());
-                clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
+                showSortedClients();
             }
 
             if (commandResult.isShowClient()) {

--- a/src/main/java/seedu/address/ui/MeetingCard.java
+++ b/src/main/java/seedu/address/ui/MeetingCard.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.meeting.Meeting;
 
@@ -24,6 +25,8 @@ public class MeetingCard extends UiPart<Region> {
     public final Meeting meeting;
 
     @FXML
+    private HBox cardPane;
+    @FXML
     private Label name;
     @FXML
     private Label id;
@@ -38,6 +41,12 @@ public class MeetingCard extends UiPart<Region> {
     public MeetingCard(Meeting meeting, int displayedIndex) {
         super(FXML);
         this.meeting = meeting;
+        if (!meeting.isUpcoming()) {
+            name.setStyle("-fx-text-fill: #ADABBC;");
+            id.setStyle("-fx-text-fill: #ADABBC;");
+            startDateTime.setStyle("-fx-text-fill: #ADABBC;");
+            endDateTime.setStyle("-fx-text-fill: #ADABBC;");
+        }
         id.setText(displayedIndex + ". ");
         String nameLabel;
         if (meeting.getLabel().isEmpty()) {

--- a/src/main/java/seedu/address/ui/MeetingListPanel.java
+++ b/src/main/java/seedu/address/ui/MeetingListPanel.java
@@ -4,6 +4,7 @@ import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
@@ -19,13 +20,21 @@ public class MeetingListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(MeetingListPanel.class);
 
     @FXML
+    private Label meetingsHeader;
+
+    @FXML
     private ListView<Meeting> meetingListView;
 
     /**
      * Creates a {@code ClientListPanel} with the given {@code ObservableList}.
      */
-    public MeetingListPanel(ObservableList<Meeting> meetingList) {
+    public MeetingListPanel(ObservableList<Meeting> meetingList, boolean isShowAll) {
         super(FXML);
+        if (isShowAll) {
+            meetingsHeader.setText("All Meetings");
+        } else {
+            meetingsHeader.setText("Upcoming Meetings");
+        }
         meetingListView.setItems(meetingList);
         meetingListView.setCellFactory(listView -> new MeetingListViewCell());
     }

--- a/src/main/resources/view/MeetingListPanel.fxml
+++ b/src/main/resources/view/MeetingListPanel.fxml
@@ -3,8 +3,13 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.geometry.Insets?>
 
 <VBox styleClass="right-panel" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <Label fx:id="meetingsHeader" styleClass="heading" text="Meetings"/>
+  <Label fx:id="meetingsHeader" styleClass="heading">
+    <padding>
+      <Insets bottom="10.0"/>
+    </padding>
+  </Label>
   <ListView fx:id="meetingListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -199,6 +199,11 @@ public class AddCommandTest {
         public void updateFilteredMeetingList(Predicate<Meeting> predicate, boolean isShowAll) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean isShowAllMeetings() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -196,7 +196,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
+        public void updateFilteredMeetingList(Predicate<Meeting> predicate, boolean isShowAll) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
Closes #151.

### Changes
- Update meeting header depending on whether all or upcoming meetings are displayed.
- Update text color depending on whether meeting is upcoming or past.
- Refactor show sorted client in MainWindow into method `showSortedClientList`.