### PR TITLE
Add `clientCount` and `sortCriteria` to `ClientListPanel` and fix `ClientDisplay` not updating on edit client

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -50,6 +51,8 @@ public interface Logic {
      * Returns the user prefs' GUI settings.
      */
     GuiSettings getGuiSettings();
+
+    Index getDisplayedClientIndex();
 
     /**
      * Set the user prefs' GUI settings.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -84,6 +85,12 @@ public class LogicManager implements Logic {
     public GuiSettings getGuiSettings() {
         return model.getGuiSettings();
     }
+
+    @Override
+    public Index getDisplayedClientIndex() {
+        return model.getDisplayedClientIndex();
+    }
+
 
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.model.client.SortCriteria;
 
 /**
  * Represents the result of a command execution.
@@ -29,16 +30,19 @@ public class CommandResult {
     private final boolean showClients;
 
     /** Clients should be sorted **/
-    private final boolean sortClients;
+    private final SortCriteria sortClients;
 
     /** Index to show. */
     private final Index indexToShow;
+
+    private final Index indexToUpdate;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean showTutorial, boolean exit,
-                         boolean showMeetings, boolean showClients, boolean sortClients, Index indexToShow) {
+                         boolean showMeetings, boolean showClients, SortCriteria sortClients, Index indexToShow,
+                         Index indexToUpdate) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.showTutorial = showTutorial;
@@ -47,13 +51,14 @@ public class CommandResult {
         this.showClients = showClients;
         this.sortClients = sortClients;
         this.indexToShow = indexToShow;
+        this.indexToUpdate = indexToUpdate;
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified fields for non-sort commands.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean showTutorial, boolean exit,
-                         boolean showMeetings, boolean showClients, Index indexToShow) {
+                         boolean showMeetings, boolean showClients, Index indexToShow, Index indexToUpdate) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.showTutorial = showTutorial;
@@ -61,15 +66,16 @@ public class CommandResult {
         this.showMeetings = showMeetings;
         this.showClients = showClients;
         this.indexToShow = indexToShow;
-        this.sortClients = false;
+        this.sortClients = null;
+        this.indexToUpdate = indexToUpdate;
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified fields for sort commands.
      */
-    public CommandResult(String feedbackToUser, boolean sortClients) {
+    public CommandResult(String feedbackToUser, SortCriteria sortClients) {
         this(feedbackToUser, false, false, false,
-                false, false, sortClients, null);
+                false, false, sortClients, null, null);
     }
 
     /**
@@ -78,7 +84,7 @@ public class CommandResult {
      */
     public CommandResult(String feedbackToUser) {
         this(feedbackToUser, false, false, false,
-                false, false, null);
+                false, false, null, null);
     }
 
     /**
@@ -87,7 +93,7 @@ public class CommandResult {
      */
     public CommandResult(String feedbackToUser, Index indexToShow) {
         this(feedbackToUser, false, false, false,
-                false, false, indexToShow);
+                false, false, indexToShow, null);
     }
 
     public String getFeedbackToUser() {
@@ -119,11 +125,23 @@ public class CommandResult {
     }
 
     public boolean isSortClients() {
-        return sortClients;
+        return sortClients != null;
     }
 
     public Index getIndexToShow() {
         return indexToShow;
+    }
+
+    public boolean isUpdateClient() {
+        return indexToUpdate != null;
+    }
+
+    public Index getIndexToUpdate() {
+        return indexToUpdate;
+    }
+
+    public SortCriteria getSortCriteria() {
+        return sortClients;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -101,7 +101,9 @@ public class EditCommand extends Command {
 
         model.setClient(clientToEdit, editedClient);
         model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
-        return new CommandResult(String.format(MESSAGE_EDIT_CLIENT_SUCCESS, editedClient));
+        model.updateDisplayedClientIndex(index);
+        return new CommandResult(String.format(MESSAGE_EDIT_CLIENT_SUCCESS, editedClient), false, false, false, false,
+                false, null, index);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, true, false, false, null);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, true, false, false, null, null);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, false, null);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, false, null, null);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,7 +19,6 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
-        return new CommandResult(MESSAGE_SUCCESS, false, false, false,
-                false, true, null);
+        return new CommandResult(MESSAGE_SUCCESS, false, false, false, false, true, null, null);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -33,7 +33,7 @@ public class SortCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Successfully sorted";
     public static final String MESSAGE_INVALID_ATTRIBUTE = "This attribute is invalid.\nThe available attributes are"
-            + " empty (default), numPolicies, premium and lastContacted.";
+            + " `empty` (default), `numPolicies`, `premium` and `lastContacted`.";
     public static final String MESSAGE_INVALID_SORT_DIRECTION = "Use 'asc' for ascending or 'desc' for descending";
 
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -32,8 +32,8 @@ public class SortCommand extends Command {
             + PREFIX_SORT_DIRECTION + "desc";
 
     public static final String MESSAGE_SUCCESS = "Successfully sorted";
-    public static final String MESSAGE_INVALID_ATTRIBUTE = "This attribute is invalid.\nThe available attributes are" +
-            " empty (default), numPolicies, premium and lastContacted.";
+    public static final String MESSAGE_INVALID_ATTRIBUTE = "This attribute is invalid.\nThe available attributes are"
+            + " empty (default), numPolicies, premium and lastContacted.";
     public static final String MESSAGE_INVALID_SORT_DIRECTION = "Use 'asc' for ascending or 'desc' for descending";
 
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -4,10 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_DIRECTION;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.SortCriteria;
 
 /**
  * Sorts clients in the address book.
@@ -30,7 +32,8 @@ public class SortCommand extends Command {
             + PREFIX_SORT_DIRECTION + "desc";
 
     public static final String MESSAGE_SUCCESS = "Successfully sorted";
-    public static final String MESSAGE_INVALID_ATTRIBUTE = "This attribute is invalid";
+    public static final String MESSAGE_INVALID_ATTRIBUTE = "This attribute is invalid.\nThe available attributes are" +
+            " empty (default), numPolicies, premium and lastContacted.";
     public static final String MESSAGE_INVALID_SORT_DIRECTION = "Use 'asc' for ascending or 'desc' for descending";
 
 
@@ -54,18 +57,26 @@ public class SortCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         Comparator<Client> comparator;
+        SortCriteria criteria;
+        if (!Objects.equals(attribute, "") && !SortCriteria.isValidEnum(attribute)) {
+            throw new CommandException(MESSAGE_INVALID_ATTRIBUTE);
+        }
         switch(attribute) {
         case "numPolicies":
             comparator = Comparator.comparingInt(a -> a.getPolicies().asUnmodifiableObservableList().size());
+            criteria = SortCriteria.numPolicies;
             break;
         case "premium":
             comparator = Comparator.comparingInt(a -> a.getPolicies().totalPremiumSum());
+            criteria = SortCriteria.premium;
             break;
         case "lastContacted":
             comparator = Comparator.comparing(a -> a.getLastContacted().getDateTime());
+            criteria = SortCriteria.lastContacted;
             break;
         default:
-            throw new CommandException(MESSAGE_INVALID_ATTRIBUTE);
+            comparator = Comparator.comparing(a -> a.getName().fullName);
+            criteria = SortCriteria.DEFAULT;
         }
 
         if (!isAscending) {
@@ -73,7 +84,7 @@ public class SortCommand extends Command {
         }
 
         model.updateSortedClientList(comparator);
-        return new CommandResult(String.format(MESSAGE_SUCCESS), true);
+        return new CommandResult(MESSAGE_SUCCESS, criteria);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/TutorialCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TutorialCommand.java
@@ -16,6 +16,6 @@ public class TutorialCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_TUTORIAL_MESSAGE, false, true, false, false, false, null);
+        return new CommandResult(SHOWING_TUTORIAL_MESSAGE, false, true, false, false, false, null, null);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
@@ -42,7 +42,8 @@ public class ViewClientCommand extends Command {
         }
 
         Client clientToView = lastShownList.get(index.getZeroBased());
+        model.updateDisplayedClientIndex(index);
         return new CommandResult(String.format(MESSAGE_SUCCESS, clientToView.getName()), false, false, false, false,
-                false, index);
+                false, index, null);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/meeting/ListMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ListMeetingCommand.java
@@ -99,12 +99,7 @@ public class ListMeetingCommand extends Command {
 
         model.updateFilteredMeetingList(generatePredicate(isShowAll, client), isShowAll);
 
-        return new CommandResult(generateSuccessMessage(isShowAll, client),
-                false,
-                false,
-                false,
-                true,
-                false,
-                null);
+        return new CommandResult(generateSuccessMessage(isShowAll, client), false, false, false, true,
+                false, null, null);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.client.Client;
 import seedu.address.model.meeting.Meeting;
 
@@ -109,6 +110,10 @@ public interface Model {
     ObservableList<Client> getSortedClientList();
 
     void updateSortedClientList(Comparator<Client> comparator);
+
+    Index getDisplayedClientIndex();
+
+    void updateDisplayedClientIndex(Index index);
 
     /**
      * Adds the given meeting.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.client.Client;
 import seedu.address.model.meeting.Meeting;
 
@@ -28,6 +29,7 @@ public class ModelManager implements Model {
     private final FilteredList<Meeting> filteredMeetings;
     private final SortedList<Client> sortedClients;
     private boolean isShowAllMeetings = false;
+    private Index displayedClient;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -155,6 +157,16 @@ public class ModelManager implements Model {
     @Override
     public void sortMeetings() {
         addressBook.sortMeetings();
+    }
+
+    @Override
+    public Index getDisplayedClientIndex() {
+        return this.displayedClient;
+    }
+
+    @Override
+    public void updateDisplayedClientIndex(Index index) {
+        this.displayedClient = index;
     }
 
     //=========== Filtered Client List Accessors =============================================================

--- a/src/main/java/seedu/address/model/client/SortCriteria.java
+++ b/src/main/java/seedu/address/model/client/SortCriteria.java
@@ -1,0 +1,25 @@
+package seedu.address.model.client;
+
+import java.util.Arrays;
+
+public enum SortCriteria {
+    numPolicies("Number of Policies"),
+    premium("Premium"),
+    lastContacted("Last Contacted"),
+    DEFAULT("Default");
+
+    private String criteria;
+
+    SortCriteria(String criteria) {
+        this.criteria = criteria;
+    }
+
+    public static boolean isValidEnum(String attribute) {
+        return Arrays.stream(SortCriteria.values()).anyMatch(e -> e.name().equals(attribute));
+    }
+
+    @Override
+    public String toString() {
+        return criteria;
+    }
+}

--- a/src/main/java/seedu/address/ui/ClientListPanel.java
+++ b/src/main/java/seedu/address/ui/ClientListPanel.java
@@ -4,11 +4,13 @@ import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.SortCriteria;
 
 /**
  * Panel containing the list of clients.
@@ -17,6 +19,12 @@ public class ClientListPanel extends UiPart<Region> {
     private static final String FXML = "ClientListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(ClientListPanel.class);
 
+    private final ObservableList<Client> clientList;
+
+    @FXML
+    private Label clientCount;
+    @FXML
+    private Label sortMethod;
     @FXML
     private ListView<Client> clientListView;
 
@@ -25,8 +33,19 @@ public class ClientListPanel extends UiPart<Region> {
      */
     public ClientListPanel(ObservableList<Client> clientList) {
         super(FXML);
+        this.clientList = clientList;
+        clientCount.setText(String.format("%d Clients", clientList.size()));
+        sortMethod.setText("Sorted by: Default");
         clientListView.setItems(clientList);
         clientListView.setCellFactory(listView -> new ClientListViewCell());
+    }
+
+    public void setClientCount() {
+        clientCount.setText(String.format("%d Clients", clientList.size()));
+    }
+
+    public void setSortCriteria(SortCriteria criteria) {
+        sortMethod.setText(String.format("Sorted by: %s", criteria));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -17,6 +17,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.client.SortCriteria;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -232,6 +233,15 @@ public class MainWindow extends UiPart<Stage> {
         clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
     }
 
+    /**
+     * Display sorted clients.
+     */
+    private void showDefaultClients() {
+        clientListPanelPlaceholder.getChildren().clear();
+        clientListPanel = new ClientListPanel(logic.getFilteredClientList());
+        clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
+    }
+
     public ClientListPanel getClientListPanel() {
         return clientListPanel;
     }
@@ -246,6 +256,8 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+
+            clientListPanel.setClientCount();
 
             if (commandResult.isShowHelp()) {
                 handleHelp();
@@ -268,11 +280,20 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             if (commandResult.isSortClients()) {
-                showSortedClients();
+                if (commandResult.getSortCriteria().equals(SortCriteria.DEFAULT)) {
+                    showDefaultClients();
+                } else {
+                    showSortedClients();
+                }
+                clientListPanel.setSortCriteria(commandResult.getSortCriteria());
             }
 
             if (commandResult.isShowClient()) {
                 showClient(commandResult.getIndexToShow());
+            }
+
+            if (commandResult.isUpdateClient() && logic.getDisplayedClientIndex() == commandResult.getIndexToUpdate()) {
+                showClient(commandResult.getIndexToUpdate());
             }
 
             return commandResult;

--- a/src/main/resources/view/ClientListCard.fxml
+++ b/src/main/resources/view/ClientListCard.fxml
@@ -23,7 +23,7 @@
       <ImageView fx:id="imageView" fitHeight="50" fitWidth="50">
         <Image url="@/images/profile.png"/>
       </ImageView>
-      <VBox GridPane.columnIndex="0">
+      <VBox minWidth="480" GridPane.columnIndex="0">
         <padding>
           <Insets left="15" />
         </padding>

--- a/src/main/resources/view/ClientListPanel.fxml
+++ b/src/main/resources/view/ClientListPanel.fxml
@@ -2,6 +2,19 @@
 
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.control.Label?>
+
+<?import javafx.geometry.Insets?>
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <HBox>
+    <Label fx:id="clientCount" styleClass="client-list-count" />
+    <Region HBox.hgrow="ALWAYS"/>
+    <Label fx:id="sortMethod" styleClass="client-list-sort" />
+    <padding>
+      <Insets left="10" bottom="8" right="25" />
+    </padding>
+  </HBox>
   <ListView fx:id="clientListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -157,6 +157,18 @@
 
 .cell_small_label {
     -fx-font-family: "Lato Light";
+    -fx-font-size: 15px;
+    -fx-text-fill: #010504;
+}
+
+.client-list-count {
+    -fx-font-family: "Lato Bold";
+    -fx-font-size: 18px;
+    -fx-text-fill: #010504;
+}
+
+.client-list-sort {
+    -fx-font-family: "Lato";
     -fx-font-size: 16px;
     -fx-text-fill: #010504;
 }
@@ -317,9 +329,9 @@
 #policies .label {
     -fx-text-fill: white;
     -fx-background-color: #3872dd;
-    -fx-padding: 1 3 1 3;
-    -fx-border-radius: 2;
-    -fx-background-radius: 2;
+    -fx-padding: 3 8 3 8;
+    -fx-border-radius: 14;
+    -fx-background-radius: 14;
     -fx-font-size: 14;
 }
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.Scene?>
 <?import javafx.stage.Stage?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="1000" minHeight="600" onCloseRequest="#handleExit">
+         title="Address App" minWidth="1000" minHeight="700" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/main/resources/view/PolicyListCard.fxml
+++ b/src/main/resources/view/PolicyListCard.fxml
@@ -13,7 +13,7 @@
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
         </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="75" GridPane.columnIndex="0">
+        <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15" />
             </padding>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -157,6 +158,16 @@ public class AddCommandTest {
 
         @Override
         public void updateSortedClientList(Comparator<Client> comparator) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Index getDisplayedClientIndex() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateDisplayedClientIndex(Index index) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false, false, null)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false, false, null, null)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -30,11 +30,11 @@ public class CommandResultTest {
 
         // different showHelp value -> returns false
         assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false, false,
-                null)));
+                null, null)));
 
         // different exit value -> returns false
         assertFalse(commandResult.equals(new CommandResult("feedback", false, false, true, false, false,
-                null)));
+                null, null)));
     }
 
     @Test
@@ -49,10 +49,10 @@ public class CommandResultTest {
 
         // different showHelp value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false, false, false,
-                null).hashCode());
+                null, null).hashCode());
 
         // different exit value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, true, false, false,
-                null).hashCode());
+                null, null).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -15,7 +15,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, true, false,
-                false, null);
+                false, null, null);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -15,7 +15,7 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, false,
-                null);
+                null, null);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
Closes #144 and fixes #131.

### Issues
- UI does not display total client count and the current sort criteria.
- Client details not updated upon edit.
- Last contacted text on `ClientListCard` is not aligned.

### Changes
- Add methods to `MainWindow` and `ClientListPanel` to update client count and sort criteria upon add and sort.
- Add an enum for `SortCriteria` and modify `CommandResult` to access `sortCriteria`.
- Modify `SortCommand` to sort by default ordering on empty sort attribute.
- Modify `Logic`, `Model` and `CommandResult` to check index of client being updated.
- Modify `MainWindow` to update `ClientDisplay` upon updating of client.
- Fix padding issues on `ClientListCard`.