### PR TITLE
Fix client card not updating on add policy

### DIFF
--- a/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
@@ -62,6 +62,7 @@ public class AddPolicyCommand extends Command {
         Client clientToAddPolicy = lastShownList.get(index.getZeroBased());
 
         clientToAddPolicy.addPolicy(policyToAdd);
+        model.setClient(clientToAddPolicy, clientToAddPolicy);
 
         return new CommandResult((String.format(MESSAGE_SUCCESS, policyToAdd)));
     }


### PR DESCRIPTION
Client card does not update automatically with new policy after adding.

### Changes
- Modify `AddPolicyCommand` to update client in `Model` upon execution