### PR TITLE
Fix incorrect client index after sort

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -36,6 +36,10 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of clients */
     ObservableList<Client> getFilteredClientList();
 
+    /** 
+     * Returns an unmodifiable view of the filtered or sorted list of clients depending on whether client list is
+     * sorted
+     */
     ObservableList<Client> getClientList();
 
     /** Returns an unmodifiable view of the filtered list of meetings */

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -36,8 +36,7 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of clients */
     ObservableList<Client> getFilteredClientList();
 
-    /** Returns an unmodifable view of the sorted list of clients */
-    ObservableList<Client> getSortedClientList();
+    ObservableList<Client> getClientList();
 
     /** Returns an unmodifiable view of the filtered list of meetings */
     ObservableList<Meeting> getFilteredMeetingList();
@@ -63,4 +62,14 @@ public interface Logic {
      * Returns whether all or only upcoming meetings are displayed.
      */
     boolean isShowAllMeetings();
+
+    /**
+     * Returns whether clients displayed are in sorted order.
+     */
+    boolean isSorted();
+
+    /**
+     * Set whether clients displayed are in sorted order.
+     */
+    void setIsSorted(boolean isSorted);
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -36,9 +36,9 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of clients */
     ObservableList<Client> getFilteredClientList();
 
-    /** 
+    /**
      * Returns an unmodifiable view of the filtered or sorted list of clients depending on whether client list is
-     * sorted
+     * sorted.
      */
     ObservableList<Client> getClientList();
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -67,8 +67,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Client> getSortedClientList() {
-        return model.getSortedClientList();
+    public ObservableList<Client> getClientList() {
+        return model.getClientList();
     }
 
     @Override
@@ -91,7 +91,6 @@ public class LogicManager implements Logic {
         return model.getDisplayedClientIndex();
     }
 
-
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
@@ -100,5 +99,15 @@ public class LogicManager implements Logic {
     @Override
     public boolean isShowAllMeetings() {
         return model.isShowAllMeetings();
+    }
+
+    @Override
+    public boolean isSorted() {
+        return model.isSorted();
+    }
+
+    @Override
+    public void setIsSorted(boolean isSorted) {
+        model.setIsSorted(isSorted);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddPreferenceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPreferenceCommand.java
@@ -45,7 +45,7 @@ public class AddPreferenceCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -33,7 +33,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/DeletePreferenceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePreferenceCommand.java
@@ -43,7 +43,7 @@ public class DeletePreferenceCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -80,7 +80,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,7 +30,7 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredClientList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_CLIENTS_LISTED_OVERVIEW, model.getFilteredClientList().size()));
+                String.format(Messages.MESSAGE_CLIENTS_LISTED_OVERVIEW, model.getClientList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -65,18 +65,22 @@ public class SortCommand extends Command {
         case "numPolicies":
             comparator = Comparator.comparingInt(a -> a.getPolicies().asUnmodifiableObservableList().size());
             criteria = SortCriteria.numPolicies;
+            model.setIsSorted(true);
             break;
         case "premium":
             comparator = Comparator.comparingInt(a -> a.getPolicies().totalPremiumSum());
             criteria = SortCriteria.premium;
+            model.setIsSorted(true);
             break;
         case "lastContacted":
             comparator = Comparator.comparing(a -> a.getLastContacted().getDateTime());
             criteria = SortCriteria.lastContacted;
+            model.setIsSorted(true);
             break;
         default:
             comparator = Comparator.comparing(a -> a.getName().fullName);
             criteria = SortCriteria.DEFAULT;
+            model.setIsSorted(false);
         }
 
         if (!isAscending) {

--- a/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
@@ -35,7 +35,7 @@ public class ViewClientCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/meeting/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/AddMeetingCommand.java
@@ -61,7 +61,7 @@ public class AddMeetingCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/meeting/ListMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ListMeetingCommand.java
@@ -86,7 +86,7 @@ public class ListMeetingCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         Client client = null;
         if (index != null) {
@@ -94,7 +94,7 @@ public class ListMeetingCommand extends Command {
                 throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
             }
 
-            client = model.getFilteredClientList().get(index.getZeroBased());
+            client = model.getClientList().get(index.getZeroBased());
         }
 
         model.updateFilteredMeetingList(generatePredicate(isShowAll, client), isShowAll);

--- a/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
@@ -53,7 +53,7 @@ public class AddPolicyCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/policy/DeletePolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/DeletePolicyCommand.java
@@ -44,7 +44,7 @@ public class DeletePolicyCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (clientIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/policy/EditPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/EditPolicyCommand.java
@@ -56,7 +56,7 @@ public class EditPolicyCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Client> lastShownList = model.getFilteredClientList();
+        List<Client> lastShownList = model.getClientList();
 
         if (clientIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
@@ -83,7 +83,6 @@ public class EditPolicyCommand extends Command {
         } catch (InvalidPolicyIndexException e) {
             throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
         }
-        assert editedPolicy != null;
         return new CommandResult((String.format(MESSAGE_SUCCESS, editedPolicy, clientToEditPolicy.getName())));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -100,14 +100,14 @@ public interface Model {
      */
     ObservableList<Client> getFilteredClientList();
 
+    ObservableList<Client> getClientList();
+
     /**
      * Updates the filter of the filtered client list to filter by the given {@code predicate}.
      *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredClientList(Predicate<Client> predicate);
-
-    ObservableList<Client> getSortedClientList();
 
     void updateSortedClientList(Comparator<Client> comparator);
 
@@ -167,5 +167,15 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredMeetingList(Predicate<Meeting> predicate, boolean isShowAll);
+
+    /**
+     * Returns whether clients displayed are in sorted order.
+     */
+    boolean isSorted();
+
+    /**
+     * Set whether clients displayed are in sorted order.
+     */
+    void setIsSorted(boolean isSorted);
 }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -100,6 +100,10 @@ public interface Model {
      */
     ObservableList<Client> getFilteredClientList();
 
+    /**
+     * Returns an unmodifiable view of the filtered or sorted list of clients depending on whether client list is
+     * sorted
+     */
     ObservableList<Client> getClientList();
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -30,6 +30,7 @@ public class ModelManager implements Model {
     private final SortedList<Client> sortedClients;
     private boolean isShowAllMeetings = false;
     private Index displayedClient;
+    private boolean isSorted = false;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -161,12 +162,22 @@ public class ModelManager implements Model {
 
     @Override
     public Index getDisplayedClientIndex() {
-        return this.displayedClient;
+        return displayedClient;
     }
 
     @Override
     public void updateDisplayedClientIndex(Index index) {
-        this.displayedClient = index;
+        displayedClient = index;
+    }
+
+    @Override
+    public boolean isSorted() {
+        return isSorted;
+    }
+
+    @Override
+    public void setIsSorted(boolean isSorted) {
+        this.isSorted = isSorted;
     }
 
     //=========== Filtered Client List Accessors =============================================================
@@ -181,14 +192,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredClientList(Predicate<Client> predicate) {
-        requireNonNull(predicate);
-        filteredClients.setPredicate(predicate);
+    public ObservableList<Client> getClientList() {
+        return isSorted ? sortedClients : filteredClients;
     }
 
     @Override
-    public ObservableList<Client> getSortedClientList() {
-        return sortedClients;
+    public void updateFilteredClientList(Predicate<Client> predicate) {
+        requireNonNull(predicate);
+        filteredClients.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -17,7 +17,6 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.client.SortCriteria;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -119,7 +118,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        clientListPanel = new ClientListPanel(logic.getFilteredClientList());
+        clientListPanel = new ClientListPanel(logic.getClientList());
         clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
 
         meetingListPanel = new MeetingListPanel(logic.getFilteredMeetingList(), logic.isShowAllMeetings());
@@ -127,7 +126,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        if (logic.getFilteredClientList().size() == 0) {
+        if (logic.getClientList().size() == 0) {
             resultDisplay.setFeedbackToUser("Add client by using the add command!");
             tutorialWindow.show();
         }
@@ -205,12 +204,12 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * List client.
+     * List clients.
      */
     private void showClients() {
         clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
 
-        if (logic.getFilteredClientList().size() == 0) {
+        if (logic.getClientList().size() == 0) {
             resultDisplay.setFeedbackToUser("Add client by using the add command!");
         }
     }
@@ -219,7 +218,7 @@ public class MainWindow extends UiPart<Stage> {
      * Display client.
      */
     private void showClient(Index index) {
-        clientDisplay = new ClientDisplay(logic.getFilteredClientList().get(index.getZeroBased()));
+        clientDisplay = new ClientDisplay(logic.getClientList().get(index.getZeroBased()));
         meetingListPanelPlaceholder.getChildren().clear();
         meetingListPanelPlaceholder.getChildren().add(clientDisplay.getRoot());
     }
@@ -227,23 +226,10 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Display sorted clients.
      */
-    private void showSortedClients() {
+    private void updateClients() {
         clientListPanelPlaceholder.getChildren().clear();
-        clientListPanel = new ClientListPanel(logic.getSortedClientList());
+        clientListPanel = new ClientListPanel(logic.getClientList());
         clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
-    }
-
-    /**
-     * Display sorted clients.
-     */
-    private void showDefaultClients() {
-        clientListPanelPlaceholder.getChildren().clear();
-        clientListPanel = new ClientListPanel(logic.getFilteredClientList());
-        clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
-    }
-
-    public ClientListPanel getClientListPanel() {
-        return clientListPanel;
     }
 
     /**
@@ -280,11 +266,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             if (commandResult.isSortClients()) {
-                if (commandResult.getSortCriteria().equals(SortCriteria.DEFAULT)) {
-                    showDefaultClients();
-                } else {
-                    showSortedClients();
-                }
+                updateClients();
                 clientListPanel.setSortCriteria(commandResult.getSortCriteria());
             }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -152,7 +152,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Client> getSortedClientList() {
+        public ObservableList<Client> getClientList() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -208,6 +208,16 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredMeetingList(Predicate<Meeting> predicate, boolean isShowAll) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean isSorted() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setIsSorted(boolean isSorted) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Fixes #162.

### Issue

- After sorting, client index still refers to the unsorted list.

### Changes
- Streamline `getFilteredClientList` and `getSortedClientList` into one method `getClientList` that checks the model state and returns the appropriate list. If the clients are currently sorted, method will return `sortedClientList`, else it will return `filteredClientList`.