### PR TITLE
Change PREFIX for preference key and details

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPreferenceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPreferenceCommand.java
@@ -16,7 +16,7 @@ public class AddPreferenceCommand extends Command {
 
     public static final String COMMAND_WORD = "addPref";
     public static final String MESSAGE_SUCCESS = "New preference added: %s: %s";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a preference to"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a preference to "
             + "the client specified by the index number used in the displayed "
             + "client list.\nParameters: INDEX (must be a positive integer)"
             + "[" + PREFIX_PREFERENCE_KEY + "PREFERENCE_KEY (one word with only alphabets)]"

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -22,8 +22,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_POLICY_MANAGER = new Prefix("pm/");
     public static final Prefix PREFIX_PREMIUM = new Prefix("$/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
-    public static final Prefix PREFIX_PREFERENCE_KEY = new Prefix("pk/");
-    public static final Prefix PREFIX_PREFERENCE_DETAIL = new Prefix("pd/");
+    public static final Prefix PREFIX_PREFERENCE_KEY = new Prefix("cat/");
+    public static final Prefix PREFIX_PREFERENCE_DETAIL = new Prefix("pref/");
     public static final Prefix PREFIX_POLICY_INDEX = new Prefix("pi/");
     public static final Prefix PREFIX_SORT_DIRECTION = new Prefix("dir/");
     public static final Prefix PREFIX_FILTER_OPERATOR = new Prefix("op/");


### PR DESCRIPTION
Bug caused by difference in prefixes for the command on the user guide and the actual application

- [X] Changed PREFIX_PREFERENCE_KEY to cat/ to match the instructions given in the User Guide
- [X} Changed PREFIX_PREFERENCE_DETAILS to pref/ to match instructions given in User Guide