### PR TITLE
Fix issue of policy commands not throwing errors correctly

### DIFF
--- a/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.exceptions.DuplicatePolicyException;
 
 
 public class AddPolicyCommand extends Command {
@@ -60,7 +61,12 @@ public class AddPolicyCommand extends Command {
         }
 
         Client clientToAddPolicy = lastShownList.get(index.getZeroBased());
-        Client updatedClient = clientToAddPolicy.addPolicy(policyToAdd);
+        Client updatedClient;
+        try {
+            updatedClient = clientToAddPolicy.addPolicy(policyToAdd);
+        } catch (DuplicatePolicyException e) {
+            throw new CommandException(e.getMessage());
+        }
         model.setClient(clientToAddPolicy, updatedClient);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, policyToAdd), false, false, false,

--- a/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/AddPolicyCommand.java
@@ -68,7 +68,7 @@ public class AddPolicyCommand extends Command {
             throw new CommandException(e.getMessage());
         }
         model.setClient(clientToAddPolicy, updatedClient);
-
+        model.updateDisplayedClient(clientToAddPolicy);
         return new CommandResult(String.format(MESSAGE_SUCCESS, policyToAdd), false, false, false,
                 false, false, null, updatedClient);
     }

--- a/src/main/java/seedu/address/logic/commands/policy/DeletePolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/DeletePolicyCommand.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.exceptions.EmptyPolicyListException;
 import seedu.address.model.policy.exceptions.InvalidPolicyIndexException;
 
 /**
@@ -51,17 +52,16 @@ public class DeletePolicyCommand extends Command {
         }
 
         Client clientToDeletePolicy = lastShownList.get(clientIndex.getZeroBased());
+        Client updatedClient;
         Policy policyToDelete;
         try {
             policyToDelete = clientToDeletePolicy.getPolicy(policyIndex.getZeroBased());
-        } catch (InvalidPolicyIndexException e) {
-            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+            updatedClient = clientToDeletePolicy.removePolicy(policyToDelete);
+        } catch (EmptyPolicyListException | InvalidPolicyIndexException e) {
+            throw new CommandException(e.getMessage());
         }
-
-        assert policyToDelete != null;
-
-        Client updatedClient = clientToDeletePolicy.removePolicy(policyToDelete);
         model.setClient(clientToDeletePolicy, updatedClient);
+        model.updateDisplayedClient(clientToDeletePolicy);
         return new CommandResult(String.format(MESSAGE_DELETE_POLICY_SUCCESS, policyToDelete,
                 clientToDeletePolicy.getName()), false, false, false,
                 false, false, null, updatedClient);

--- a/src/main/java/seedu/address/logic/commands/policy/EditPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/policy/EditPolicyCommand.java
@@ -21,7 +21,9 @@ import seedu.address.model.client.Client;
 import seedu.address.model.client.Name;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.Premium;
+import seedu.address.model.policy.exceptions.DuplicatePolicyException;
 import seedu.address.model.policy.exceptions.InvalidPolicyIndexException;
+import seedu.address.model.policy.exceptions.PolicyNotEditedException;
 
 /**
  * Edits a client identified using it's displayed index from the address book.
@@ -92,9 +94,14 @@ public class EditPolicyCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
         }
 
-        Client updatedClient = clientToEditPolicy.setPolicy(policyIndex.getZeroBased(), editedPolicy);
+        Client updatedClient;
+        try {
+            updatedClient = clientToEditPolicy.setPolicy(policyIndex.getZeroBased(), editedPolicy);
+        } catch (InvalidPolicyIndexException | PolicyNotEditedException | DuplicatePolicyException e) {
+            throw new CommandException(e.getMessage());
+        }
         model.setClient(clientToEditPolicy, updatedClient);
-
+        model.updateDisplayedClient(updatedClient);
         return new CommandResult((String.format(MESSAGE_SUCCESS, editedPolicy, clientToEditPolicy.getName())),
                 false, false, false, false, false, null, updatedClient);
     }

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -154,6 +154,7 @@ public class Client {
     public Client addPolicy(Policy policyToAdd) {
         UniquePolicyList updatedPolicyList = new UniquePolicyList();
         updatedPolicyList.setPolicies(policies);
+
         updatedPolicyList.add(policyToAdd);
         return new Client(name, phone, email, address, birthday, lastContacted, tags, updatedPolicyList, note,
                 preferences);

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import javafx.collections.ObservableList;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.UniquePolicyList;
+import seedu.address.model.policy.exceptions.EmptyPolicyListException;
 import seedu.address.model.policy.exceptions.InvalidPolicyIndexException;
 import seedu.address.model.tag.Tag;
 
@@ -140,9 +141,13 @@ public class Client {
                 && otherClient.getName().equals(getName());
     }
 
-    public Policy getPolicy(int index) throws InvalidPolicyIndexException {
+    public Policy getPolicy(int index) throws EmptyPolicyListException, InvalidPolicyIndexException {
         List<Policy> policyList = policies.asUnmodifiableObservableList();
-        if (index >= policyList.size()) {
+
+        if (policyList.isEmpty()) {
+            throw new EmptyPolicyListException();
+        }
+        if (index < 0 || index >= policyList.size()) {
             throw new InvalidPolicyIndexException();
         }
         return policyList.get(index);

--- a/src/main/java/seedu/address/model/policy/UniquePolicyList.java
+++ b/src/main/java/seedu/address/model/policy/UniquePolicyList.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.client.Name;
 import seedu.address.model.policy.exceptions.DuplicatePolicyException;
 import seedu.address.model.policy.exceptions.InvalidPolicyIndexException;
+import seedu.address.model.policy.exceptions.PolicyNotEditedException;
 
 /**
  * A list of policies that enforces uniqueness between its elements and does not allow nulls.
@@ -41,7 +42,7 @@ public class UniquePolicyList implements Iterable<Policy> {
      * Adds a policy to the list.
      * The policy must not already exist in the list.
      */
-    public void add(Policy toAdd) {
+    public void add(Policy toAdd) throws DuplicatePolicyException {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicatePolicyException();
@@ -54,7 +55,9 @@ public class UniquePolicyList implements Iterable<Policy> {
      * {@code target} must exist in the list.
      * The policy identity of {@code editedPolicy} must not be the same as another existing policy in the list.
      */
-    public void setPolicy(Policy target, Policy editedPolicy) {
+    public void setPolicy(Policy target, Policy editedPolicy) throws InvalidPolicyIndexException,
+            PolicyNotEditedException,
+            DuplicatePolicyException {
         requireAllNonNull(target, editedPolicy);
 
         int index = internalList.indexOf(target);
@@ -62,18 +65,32 @@ public class UniquePolicyList implements Iterable<Policy> {
             throw new InvalidPolicyIndexException();
         }
 
-        if (!target.isSamePolicy(editedPolicy) && contains(editedPolicy)) {
+        if (target.equals(editedPolicy)) {
+            throw new PolicyNotEditedException();
+        }
+
+        if (!setDoesNotCreateDuplicate(target, editedPolicy)) {
             throw new DuplicatePolicyException();
         }
 
+
         internalList.set(index, editedPolicy);
+    }
+
+    private boolean setDoesNotCreateDuplicate(Policy target, Policy editedPolicy) {
+        for (Policy p : internalUnmodifiableList) {
+            if (!p.equals(target) && p.isSamePolicy(editedPolicy)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
      * Removes the equivalent policy from the list.
      * The policy must exist in the list.
      */
-    public void remove(Policy toRemove) {
+    public void remove(Policy toRemove) throws InvalidPolicyIndexException {
         requireNonNull(toRemove);
         if (!internalList.remove(toRemove)) {
             throw new InvalidPolicyIndexException();

--- a/src/main/java/seedu/address/model/policy/UniquePolicyList.java
+++ b/src/main/java/seedu/address/model/policy/UniquePolicyList.java
@@ -10,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.client.Name;
 import seedu.address.model.policy.exceptions.DuplicatePolicyException;
+import seedu.address.model.policy.exceptions.EmptyPolicyListException;
 import seedu.address.model.policy.exceptions.InvalidPolicyIndexException;
 import seedu.address.model.policy.exceptions.PolicyNotEditedException;
 
@@ -90,8 +91,11 @@ public class UniquePolicyList implements Iterable<Policy> {
      * Removes the equivalent policy from the list.
      * The policy must exist in the list.
      */
-    public void remove(Policy toRemove) throws InvalidPolicyIndexException {
+    public void remove(Policy toRemove) throws EmptyPolicyListException, InvalidPolicyIndexException {
         requireNonNull(toRemove);
+        if (internalList.isEmpty()) {
+            throw new EmptyPolicyListException();
+        }
         if (!internalList.remove(toRemove)) {
             throw new InvalidPolicyIndexException();
         }

--- a/src/main/java/seedu/address/model/policy/exceptions/EmptyPolicyListException.java
+++ b/src/main/java/seedu/address/model/policy/exceptions/EmptyPolicyListException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.policy.exceptions;
+
+/**
+ * Signals that the operation is not possible because the given policy index is not a valid one.
+ */
+public class EmptyPolicyListException extends RuntimeException {
+    public EmptyPolicyListException() {
+        super("This client has no policies");
+    }
+}

--- a/src/main/java/seedu/address/model/policy/exceptions/PolicyNotEditedException.java
+++ b/src/main/java/seedu/address/model/policy/exceptions/PolicyNotEditedException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.policy.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Policies (Policies are considered duplicates if they have the
+ * same identity).
+ */
+public class PolicyNotEditedException extends RuntimeException {
+    public PolicyNotEditedException() {
+        super("The edited policy is the same as the original policy");
+    }
+}


### PR DESCRIPTION
- [x] AddPolicyCommand now accurately detects if a duplicated policy is being added and will throw an error
- [x] EditPolicyCommand now accurately detects if the edited policy is the same as the policy it is replacing or the same as any other policy owned by the client and will throw an error
- [x] DeletePolicyCommand now specifically checks if policy list is empty first and will throw an error 
- [x] All 3 commands now correctly update the UI
