### PR TITLE
Fix the 'bug' that meetings command does not work

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -248,6 +248,7 @@ Examples:
 Shows upcoming or all meetings.
 
 - If an index is provided, only shows meetings with the specified client.
+- If the `all/` flag is omitted, **ONLY** shows upcoming meetings (meetings that start today or in the future). 
 - If the `all/` flag is provided, shows all meetings instead of just upcoming meetings.
 
 Format: `meetings [INDEX] [all/]`

--- a/src/main/java/seedu/address/logic/commands/meeting/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/AddMeetingCommand.java
@@ -25,7 +25,10 @@ import seedu.address.model.meeting.Meeting;
 public class AddMeetingCommand extends Command {
 
     public static final String COMMAND_WORD = "addMeeting";
-    public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
+    public static final String MESSAGE_SUCCESS_UPCOMING = "New upcoming meeting added: %1$s\n"
+            + "View your upcoming meetings with the `meetings` command";
+    public static final String MESSAGE_SUCCESS_PAST = "New past meeting added: %1$s\n"
+            + "View all your meetings with the `meetings all/` command";
     public static final String MESSAGE_USAGE = "Parameters:\n• INDEX (must be a positive integer) "
             + "" + PREFIX_START_DATETIME + "START_DATETIME "
             + "" + PREFIX_END_DATETIME + "END_DATETIME "
@@ -77,7 +80,15 @@ public class AddMeetingCommand extends Command {
 
         model.addMeeting(newMeeting);
         model.sortMeetings();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, newMeeting));
+
+        String successMessage;
+        if (newMeeting.isUpcoming()) {
+            successMessage = MESSAGE_SUCCESS_UPCOMING;
+        } else {
+            successMessage = MESSAGE_SUCCESS_PAST;
+        }
+
+        return new CommandResult(String.format(successMessage, newMeeting));
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -200,7 +200,14 @@ public class MainWindow extends UiPart<Stage> {
         meetingListPanelPlaceholder.getChildren().add(meetingListPanel.getRoot());
 
         if (logic.getFilteredMeetingList().size() == 0) {
-            resultDisplay.setFeedbackToUser("No meetings to display.\nAdd meetings by using the addMeeting command!");
+            if (logic.getAddressBook().getMeetingList().size() == 0) {
+                resultDisplay.setFeedbackToUser("No meetings found.\n"
+                        + "Add meetings by using the `addMeeting` command!");
+            } else {
+                resultDisplay.setFeedbackToUser("No upcoming meetings found.\n"
+                        + "View all meetings (including past meetings) by using the `meetings all/` command!\n"
+                        + "Add meetings by using the `addMeeting` command!\n");
+            }
         }
     }
 


### PR DESCRIPTION
`meetings` command does in fact work, but the messages and UG were not clear enough to indicate that ONLY meetings in the future will be displayed
- [x] Update the success message when a past meeting vs an upcoming meeting is added
- [x] Update the response message by the client when no upcoming meetings vs no meetings are found
- [x] Update the UG to highlight that **ONLY** upcoming meetings are displayed if the `all/` flag is omitted
Closes #222, #199, #194 