### PR TITLE
Fix last contacted hidden when name is too long

### DIFF
--- a/src/main/resources/view/ClientListCard.fxml
+++ b/src/main/resources/view/ClientListCard.fxml
@@ -35,9 +35,12 @@
             </minWidth>
           </Label>
           <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
-          <Region HBox.hgrow="ALWAYS"/>
-          <Label fx:id="lastContacted" styleClass="cell_grey_label" text="\$lastContacted" />
         </HBox>
+        <Label fx:id="lastContacted" styleClass="cell_grey_label" text="\$lastContacted">
+          <padding>
+            <Insets top="3" />
+          </padding>
+        </Label>
         <FlowPane fx:id="policies">
           <padding>
             <Insets top="10" />


### PR DESCRIPTION
Fixes #201.

Name truncation is by design. Apple contacts also truncates.
Fix last contacted blocked when name is too long.