### PR TITLE
[PE-D] Fix `lastContacted`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY] "
-            + "[" + PREFIX_LAST_CONTACTED + "LAST CONTACTED]\n"
+            + "[" + PREFIX_LAST_CONTACTED + "LAST_CONTACTED]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com"
@@ -86,8 +86,8 @@ public class EditCommand extends Command {
 
         try {
             editedClient = createEditedClient(clientToEdit, editClientDescriptor);
-        } catch (DuplicatePolicyException dpe) {
-            throw new CommandException(dpe.getMessage());
+        } catch (DuplicatePolicyException e) {
+            throw new CommandException(e.getMessage());
         }
 
         if (!clientToEdit.isSameClient(editedClient) && model.hasClient(editedClient)) {

--- a/src/main/java/seedu/address/logic/parser/ContactedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ContactedCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.commands.ContactedCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/ContactedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ContactedCommandParser.java
@@ -35,7 +35,7 @@ public class ContactedCommandParser implements Parser<ContactedCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException((String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE)));
+            throw new ParseException((String.format(MESSAGE_INVALID_COMMAND_FORMAT, ContactedCommand.MESSAGE_USAGE)));
         }
 
         EditCommand.EditClientDescriptor editClientDescriptor = new EditCommand.EditClientDescriptor();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -117,6 +117,9 @@ public class ParserUtil {
         if (!DateTime.isValidDateTime(trimmedDateTime)) {
             throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
         }
+        if (!DateTime.isPastDateTime(trimmedDateTime)) {
+            throw new ParseException(DateTime.MESSAGE_FUTURE_DATETIME);
+        }
         return new DateTime(trimmedDateTime);
     }
 

--- a/src/main/java/seedu/address/model/client/DateTime.java
+++ b/src/main/java/seedu/address/model/client/DateTime.java
@@ -12,16 +12,17 @@ import java.time.format.DateTimeFormatter;
  */
 public class DateTime {
 
-    public static final String MESSAGE_CONSTRAINTS = "Datetime should be in dd-MM-yyy HH:mm format.";
+    public static final String MESSAGE_CONSTRAINTS = "Datetime should be a valid datetime in dd-MM-yyy HH:mm format.";
+    public static final String MESSAGE_FUTURE_DATETIME = "Datetime should not be in the future.";
 
     /*
      * Datetime should be in dd-MM-yyyy HH:mm format.
      */
     public static final String VALIDATION_REGEX =
-            "(((0[1-9]|[12]\\d|3[01])-(0[13578]|1[02])-((19|[2-9]\\d)\\d{2}))|((0[1-9]|[12]\\d|30)" +
-                    "-(0[13456789]|1[012])-((19|[2-9]\\d)\\d{2}))|((0[1-9]|1\\d|2[0-8])-02-((19|[2-9]\\d)\\d{2}))" +
-                    "|(29-02-((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))))" +
-                    "\\s+([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
+            "(((0[1-9]|[12]\\d|3[01])-(0[13578]|1[02])-((19|[2-9]\\d)\\d{2}))|((0[1-9]|[12]\\d|30)"
+                    + "-(0[13456789]|1[012])-((19|[2-9]\\d)\\d{2}))|((0[1-9]|1\\d|2[0-8])-02-((19|[2-9]\\d)\\d{2}))"
+                    + "|(29-02-((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))))"
+                    + "\\s+([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
 
     public final String value;
 
@@ -37,6 +38,7 @@ public class DateTime {
     public DateTime(String dateTime) {
         requireNonNull(dateTime);
         checkArgument(isValidDateTime(dateTime), MESSAGE_CONSTRAINTS);
+        checkArgument(isPastDateTime(dateTime), MESSAGE_FUTURE_DATETIME);
         value = dateTime;
     }
 
@@ -45,6 +47,14 @@ public class DateTime {
      */
     public static boolean isValidDateTime(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is a past datetime.
+     */
+    public static boolean isPastDateTime(String test) {
+        LocalDateTime testDateTime = LocalDateTime.parse(test, DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
+        return !testDateTime.isAfter(LocalDateTime.now());
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/DateTime.java
+++ b/src/main/java/seedu/address/model/client/DateTime.java
@@ -12,13 +12,16 @@ import java.time.format.DateTimeFormatter;
  */
 public class DateTime {
 
-    public static final String MESSAGE_CONSTRAINTS = "Datetime should be in DD-MM-YYYY HH:mm format.";
+    public static final String MESSAGE_CONSTRAINTS = "Datetime should be in dd-MM-yyy HH:mm format.";
 
     /*
      * Datetime should be in dd-MM-yyyy HH:mm format.
      */
     public static final String VALIDATION_REGEX =
-            "^([012][1-9]|3[01])-([0][1-9]|1[012])-([0-9][0-9][0-9][0-9])\\s([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
+            "(((0[1-9]|[12]\\d|3[01])-(0[13578]|1[02])-((19|[2-9]\\d)\\d{2}))|((0[1-9]|[12]\\d|30)" +
+                    "-(0[13456789]|1[012])-((19|[2-9]\\d)\\d{2}))|((0[1-9]|1\\d|2[0-8])-02-((19|[2-9]\\d)\\d{2}))" +
+                    "|(29-02-((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))))" +
+                    "\\s+([0-1]?[0-9]|2?[0-3]):([0-5]\\d)$";
 
     public final String value;
 
@@ -65,20 +68,6 @@ public class DateTime {
                 || (other instanceof DateTime // instanceof handles nulls
                 && value.equals(((DateTime) other).value)); // state check
     }
-
-    //    public boolean isBefore(DateTime other) {
-    //        if (parse(value).isBefore(parse(other.value))) {
-    //            return true;
-    //        }
-    //        return false;
-    //    }
-    //
-    //    public boolean isAfter(DateTime other) {
-    //        if (parse(value).isAfter(parse(other.value))) {
-    //            return true;
-    //        }
-    //        return false;
-    //    }
 
     @Override
     public int hashCode() {

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -172,6 +172,9 @@ class JsonAdaptedClient {
             if (!DateTime.isValidDateTime(lastContacted)) {
                 throw new IllegalValueException(DateTime.MESSAGE_CONSTRAINTS);
             }
+            if (!DateTime.isPastDateTime(lastContacted)) {
+                throw new IllegalValueException(DateTime.MESSAGE_FUTURE_DATETIME);
+            }
             modelLastContacted = new DateTime(lastContacted);
         }
 


### PR DESCRIPTION
### Changes

- [x] Fix `contacted` command accepting invalid dates such as `31/02/2022 21:03`, closes #207 
- [x] Fix `contacted` command showing wrong invalid format message, closes #204 
- [x] Fix `contacted` command not accepting >1 whitespace in-between date and time, closes #178 
- [x] Fix `contacted` and `updateClient` command allowing future date times for `lastContacted`, closes #224